### PR TITLE
manually review all champion lists

### DIFF
--- a/challenges.json
+++ b/challenges.json
@@ -383,7 +383,7 @@
       "Zed",
       "Zyra"
     ],
-    "qte": "3"
+    "qte": "5"
   },
   {
     "challenge_name": "It's a Trap!",

--- a/challenges.json
+++ b/challenges.json
@@ -46,6 +46,7 @@
       "Orianna",
       "Ornn",
       "Pantheon",
+      "Qiyana",
       "Rakan",
       "Rammus",
       "Rell",


### PR DESCRIPTION
- add Qiyana to 'it has ultimate in the name'
- "summoners on the rift" (harmony) requires 5 champions so amend qte

