### PR TITLE
Added #9, made champion search more accessible 

### DIFF
--- a/regions.py
+++ b/regions.py
@@ -65,16 +65,40 @@ regions = [
         "country_codes": ["AU", "NZ"],
     },
     {
+        "id": "PH2",
+        "name": "Philippines",
+        "abbreviation": "PH",
+        "country_codes": ["PH"]
+    },
+    {
         "id": "RU1",
         "name": "Russia",
         "abbreviation": "RU",
         "country_codes": ["RU"],
     },
     {
+        "id": "SG2",
+        "name": "Singapore",
+        "abbreviation": "SG",
+        "country_codes": ["SG"]
+    },
+    {
+        "id": "TH2",
+        "name": "Thailand",
+        "abbreviation": "TH",
+        "country_codes": ["TH"],
+    },
+    {
         "id": "TR1",
         "name": "Turkey",
         "abbreviation": "TR",
         "country_codes": ["TR"],
+    },
+    {
+        "id": "TW2",
+        "name": "Taiwan",
+        "abbreviation": "TW",
+        "country_codes": ["TW"],
     },
     {
         "id": "JP1",
@@ -87,6 +111,12 @@ regions = [
         "name": "Republic of Korea",
         "abbreviation": "KR",
         "country_codes": ["KR"],
+    },
+    {
+        "id": "VN2",
+        "name": "Vietnam",
+        "abbreviation": "VN",
+        "country_codes": ["VN"],
     },
 ]
 regions.sort(key=lambda r: r["abbreviation"])

--- a/static/js/team_builder.js
+++ b/static/js/team_builder.js
@@ -363,10 +363,13 @@ search_champion.addEventListener("input", function (e) {
          * By using the internal id, it is easier to search champions 
          * like Vel'Koz, as you don't have to add the apostrophe or space
          */
-        if (
-            c.dataset.champion_display_name.toLowerCase().includes(e.target.value.toLowerCase())
-            || c.dataset.champion_name.toLowerCase().includes(e.target.value.toLowerCase())
-        ) {
+        let query = e.target.value.toLowerCase()
+        let targets = [
+            c.dataset.champion_display_name,
+            c.dataset.champion_name,
+        ]
+
+        if (targets.some((e) => e.toLowerCase().includes(query))) {
             c.parentElement.style.display = "block"
         }
     }

--- a/static/js/team_builder.js
+++ b/static/js/team_builder.js
@@ -357,8 +357,18 @@ search_champion.addEventListener("input", function (e) {
         c.parentElement.style.display = "none"
     }
     for (let c of champion_img) {
-        if (c.dataset.champion_display_name.toLowerCase().includes(e.target.value.toLowerCase()))
+
+        /**
+         * Make a champion searchable by name or internal id
+         * By using the internal id, it is easier to search champions 
+         * like Vel'Koz, as you don't have to add the apostrophe or space
+         */
+        if (
+            c.dataset.champion_display_name.toLowerCase().includes(e.target.value.toLowerCase())
+            || c.dataset.champion_name.toLowerCase().includes(e.target.value.toLowerCase())
+        ) {
             c.parentElement.style.display = "block"
+        }
     }
 })
 


### PR DESCRIPTION
Quote a comment from a commit:
>Make a champion searchable by name or internal id
> By using the internal id, it is easier to search champions like Vel'Koz, as you don't have to add the apostrophe or space

Also, added new region as request (by myself, lol) in #9 
