### PR TITLE
Fix Enter in multiseatch leading to "not found" problems

### DIFF
--- a/static/js/multisearch.js
+++ b/static/js/multisearch.js
@@ -66,6 +66,10 @@ text_area_multisearch.addEventListener("paste", event => {
                 l = l.replace(j, "")
             }
         }
+
+        if (l) { // Ensure only non-empty lines are added
+            summoners_names.add(l);
+        }
         summoners_names.add(l)
     }
     if (summoners_names.size > 0) {


### PR DESCRIPTION
Right now, when you press ENTER after pasting names, you create a new line. In the code this leads to a new line, which will be empty, and even after clearing its empty, but still gets added to the names. 

This PR adds a simple check to not add empty lines to the summoner names